### PR TITLE
Cerrar sesión, muestra nombre y correo de usuario. Resolución de bug

### DIFF
--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -29,75 +29,67 @@ class _HomePageState extends State<HomePage>
 
   @override
   Widget build(BuildContext context) {
-    // TODO: implement build
-    return MaterialApp(
-        debugShowCheckedModeBanner: false,
-        //color: Hexcolor('#FF9800'),
-        theme: ThemeData(brightness: Brightness.light, accentColor: Colors.red),
-        darkTheme: ThemeData(
-          brightness: Brightness.dark,
-        ),
-        home: new Scaffold(
-          appBar: buildAppBar(),
-          body: TabBarView(
-            children: <Widget>[
-              //para pruebas se comenta el FirstTab(),
-              //Text('Hola Mundo'),
-              FirstTab(),
-              Text('Hola Mundo'),
-              MyBody("Page Three"),
-              ProfilePage(),
-            ],
+    return Scaffold(
+      appBar: buildAppBar(),
+      body: TabBarView(
+        children: <Widget>[
+          //para pruebas se comenta el FirstTab(),
+          //Text('Hola Mundo'),
+          FirstTab(),
+          Text('Hola Mundo'),
+          MyBody("Page Three"),
+          ProfilePage(),
+        ],
 // if you want yo disable swiping in tab the use below code
 //            physics: NeverScrollableScrollPhysics(),
-            controller: tabController,
-          ),
-          bottomNavigationBar: Material(
-            color: Color(0xFFFF9800),
-            child: TabBar(
-              onTap: (indedx) {
-                if (indedx == 0) {
-                  setState(() {
-                    title = "Home";
-                  });
-                } else if (indedx == 1) {
-                  setState(() {
-                    title = "Wishlist";
-                  });
-                } else if (indedx == 2) {
-                  setState(() {
-                    title = "Cart";
-                  });
-                } else if (indedx == 3) {
-                  setState(() {
-                    title = "Account";
-                  });
-                }
-              },
-              indicatorColor: Colors.white,
-              unselectedLabelColor: Colors.white,
-              tabs: <Widget>[
-                Tab(
-                  icon: Icon(Icons.home),
-                  text: "Home",
-                ),
-                Tab(
-                  icon: Icon(Icons.favorite),
-                  text: "Wishlist",
-                ),
-                Tab(
-                  icon: Icon(Icons.shopping_cart),
-                  text: "Cart",
-                ),
-                Tab(
-                  icon: Icon(Icons.account_circle),
-                  text: "Account",
-                ),
-              ],
-              controller: tabController,
+        controller: tabController,
+      ),
+      bottomNavigationBar: Material(
+        color: Color(0xFFFF9800),
+        child: TabBar(
+          onTap: (indedx) {
+            if (indedx == 0) {
+              setState(() {
+                title = "Home";
+              });
+            } else if (indedx == 1) {
+              setState(() {
+                title = "Wishlist";
+              });
+            } else if (indedx == 2) {
+              setState(() {
+                title = "Cart";
+              });
+            } else if (indedx == 3) {
+              setState(() {
+                title = "Account";
+              });
+            }
+          },
+          indicatorColor: Colors.white,
+          unselectedLabelColor: Colors.white,
+          tabs: <Widget>[
+            Tab(
+              icon: Icon(Icons.home),
+              text: "Home",
             ),
-          ),
-        ));
+            Tab(
+              icon: Icon(Icons.favorite),
+              text: "Wishlist",
+            ),
+            Tab(
+              icon: Icon(Icons.shopping_cart),
+              text: "Cart",
+            ),
+            Tab(
+              icon: Icon(Icons.account_circle),
+              text: "Account",
+            ),
+          ],
+          controller: tabController,
+        ),
+      ),
+    );
   }
 
   AppBar buildAppBar() {

--- a/lib/pages/profile_page.dart
+++ b/lib/pages/profile_page.dart
@@ -1,8 +1,13 @@
+import 'package:com_app_tienda/Users/blocs/authentication_bloc/authentication_bloc.dart';
+import 'package:com_app_tienda/Users/blocs/authentication_bloc/authentication_event.dart';
+import 'package:com_app_tienda/Users/blocs/authentication_bloc/authentication_state.dart';
+import 'package:com_app_tienda/Users/models/user_entity.dart';
 import 'package:com_app_tienda/models/user.dart';
 import 'package:com_app_tienda/pages/ProfileSettingsDialog.dart';
 import 'package:com_app_tienda/pages/afiliacion_page.dart';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:page_transition/page_transition.dart';
 
 class ProfilePage extends StatefulWidget {
@@ -14,124 +19,178 @@ class ProfilePage extends StatefulWidget {
 
 class _ProfilePageState extends State<ProfilePage> {
   User _user = new User.init().getCurrentUser();
+  UserEntity user = UserEntity();
+  AuthenticationBloc authenticationBloc;
+  @override
+  void initState() {
+    super.initState();
+    authenticationBloc = BlocProvider.of<AuthenticationBloc>(context);
+  }
+
   @override
   Widget build(BuildContext context) {
-    return SingleChildScrollView(
-      padding: EdgeInsets.symmetric(vertical: 7),
-      child: Column(
-        children: <Widget>[
-          Container(
-            margin: EdgeInsets.symmetric(horizontal: 20, vertical: 15),
-            decoration: BoxDecoration(
-              color: Color(0xFFFFFFFF),
-              borderRadius: BorderRadius.circular(6),
-              boxShadow: [BoxShadow(offset: Offset(0, 3), blurRadius: 10)],
-            ),
-            child: ListView(
-              shrinkWrap: true,
-              primary: false,
-              children: <Widget>[
-                ListTile(
-                  onTap: () {},
-                  leading: Icon(Icons.perm_identity),
-                  title: Text(
-                    'Profile Settings',
-                  ),
-                  trailing: ButtonTheme(
-                    padding: EdgeInsets.all(0),
-                    minWidth: 50.0,
-                    height: 25.0,
-                    child: ProfileSettingsDialog(
-                      user: this._user,
-                      onChanged: () {
-                        setState(() {});
-                      },
+    return BlocBuilder<AuthenticationBloc, AuthenticationState>(
+        builder: (BuildContext context, AuthenticationState state) {
+          if (state is Authenticated) {
+            user = state.user;
+          }
+      return BlocListener<AuthenticationBloc, AuthenticationState>(
+        listener: (BuildContext context, AuthenticationState state) {
+          if (state is Unauthenticated) {
+            Navigator.pushReplacementNamed(context, '/login');
+          }
+        },
+        child: SingleChildScrollView(
+          padding: EdgeInsets.symmetric(vertical: 7),
+          child: Column(
+            children: <Widget>[
+              Container(
+                margin: EdgeInsets.symmetric(horizontal: 20, vertical: 15),
+                decoration: BoxDecoration(
+                  color: Color(0xFFFFFFFF),
+                  borderRadius: BorderRadius.circular(6),
+                  boxShadow: [BoxShadow(offset: Offset(0, 3), blurRadius: 10)],
+                ),
+                child: ListView(
+                  shrinkWrap: true,
+                  primary: false,
+                  children: <Widget>[
+                    ListTile(
+                      onTap: () {},
+                      leading: Icon(Icons.perm_identity),
+                      title: Text(
+                        'Profile Settings',
+                      ),
+                      trailing: ButtonTheme(
+                        padding: EdgeInsets.all(0),
+                        minWidth: 50.0,
+                        height: 25.0,
+                        child: ProfileSettingsDialog(
+                          user: this._user,
+                          onChanged: () {
+                            setState(() {});
+                          },
+                        ),
+                      ),
                     ),
-                  ),
+                    ListTile(
+                      dense: true,
+                      title: Text(
+                        'Full name',
+                      ),
+                      trailing: Text(
+                        '${user.displayName}',
+                      ),
+                    ),
+                    ListTile(
+                      dense: true,
+                      title: Text(
+                        'Email',
+                      ),
+                      trailing: Text(
+                        '${user.email}',
+                      ),
+                    ),
+                  ],
                 ),
-                ListTile(
-                  dense: true,
-                  title: Text(
-                    'Full name',
-                  ),
-                  trailing: Text(
-                    _user.name,
-                  ),
+              ),
+              Container(
+                margin: EdgeInsets.symmetric(horizontal: 20, vertical: 15),
+                decoration: BoxDecoration(
+                  color: Color(0xFFFFFFFF),
+                  borderRadius: BorderRadius.circular(6),
+                  boxShadow: [BoxShadow(offset: Offset(0, 3), blurRadius: 10)],
                 ),
-                ListTile(
-                  dense: true,
-                  title: Text(
-                    'Email',
-                  ),
-                  trailing: Text(
-                    _user.email,
-                  ),
+                child: ListView(
+                  shrinkWrap: true,
+                  primary: false,
+                  children: <Widget>[
+                    ListTile(
+                      onTap: () {},
+                      leading: Icon(Icons.check),
+                      title: Text(
+                        'Affiliate',
+                      ),
+                    ),
+                    ListTile(
+                      dense: true,
+                      title: Text(
+                        'Full name:',
+                      ),
+                      trailing: Text(
+                        _user.name,
+                      ),
+                    ),
+                    ListTile(
+                      dense: true,
+                      title: Text(
+                        'Estado:',
+                      ),
+                      trailing: Text(
+                        'No Affiliate',
+                      ),
+                    ),
+                    ListTile(
+                      dense: true,
+                      title: Text(
+                        'Fecha de envio:',
+                      ),
+                      trailing: Text(
+                        '----',
+                      ),
+                    ),
+                    Container(
+                      padding: EdgeInsets.symmetric(vertical: 15.0),
+                      width: double.infinity,
+                      child: RaisedButton(
+                        elevation: 4.0,
+                        onPressed: () => Navigator.push(
+                            context,
+                            PageTransition(
+                                type: PageTransitionType.fade,
+                                child: Afiliacion())),
+                        padding: EdgeInsets.all(10.0),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(30.0),
+                        ),
+                        color: Colors.yellow,
+                        child: Text(
+                          'Ingresar Solicitud',
+                          style: TextStyle(
+                            color: Color(0xFF527DAA),
+                            letterSpacing: 1.5,
+                            fontSize: 18.0,
+                            fontWeight: FontWeight.bold,
+                            fontFamily: 'OpenSans',
+                          ),
+                        ),
+                      ),
+                    )
+                  ],
                 ),
-              ],
-            ),
-          ),
-          Container(
-            margin: EdgeInsets.symmetric(horizontal: 20, vertical: 15),
-            decoration: BoxDecoration(
-              color: Color(0xFFFFFFFF),
-              borderRadius: BorderRadius.circular(6),
-              boxShadow: [BoxShadow(offset: Offset(0, 3), blurRadius: 10)],
-            ),
-            child: ListView(
-              shrinkWrap: true,
-              primary: false,
-              children: <Widget>[
-                ListTile(
-                  onTap: () {},
-                  leading: Icon(Icons.check),
-                  title: Text(
-                    'Affiliate',
-                  ),
+              ),
+              Container(
+                margin: EdgeInsets.symmetric(horizontal: 20, vertical: 15),
+                decoration: BoxDecoration(
+                  color: Color(0xFFFFFFFF),
+                  borderRadius: BorderRadius.circular(6),
+                  boxShadow: [BoxShadow(offset: Offset(0, 3), blurRadius: 10)],
                 ),
-                ListTile(
-                  dense: true,
-                  title: Text(
-                    'Full name:',
-                  ),
-                  trailing: Text(
-                    _user.name,
-                  ),
-                ),
-                ListTile(
-                  dense: true,
-                  title: Text(
-                    'Estado:',
-                  ),
-                  trailing: Text(
-                    'No Affiliate',
-                  ),
-                ),
-                ListTile(
-                  dense: true,
-                  title: Text(
-                    'Fecha de envio:',
-                  ),
-                  trailing: Text(
-                    '----',
-                  ),
-                ),
-                Container(
+                child: Container(
                   padding: EdgeInsets.symmetric(vertical: 15.0),
                   width: double.infinity,
                   child: RaisedButton(
                     elevation: 4.0,
-                    onPressed: () => Navigator.push(
-                        context,
-                        PageTransition(
-                            type: PageTransitionType.fade,
-                            child: Afiliacion())),
+                    onPressed: (){
+                      authenticationBloc.add(LoggedOut());
+                    },
                     padding: EdgeInsets.all(10.0),
                     shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(30.0),
                     ),
                     color: Colors.yellow,
                     child: Text(
-                      'Ingresar Solicitud',
+                      'Cerrar Sesión',
                       style: TextStyle(
                         color: Color(0xFF527DAA),
                         letterSpacing: 1.5,
@@ -141,12 +200,12 @@ class _ProfilePageState extends State<ProfilePage> {
                       ),
                     ),
                   ),
-                )
-              ],
-            ),
+                ),
+              )
+            ],
           ),
-        ],
-      ),
-    );
+        ),
+      );
+    });
   }
 }


### PR DESCRIPTION
- Agregué un botón en el perfil de usuario que te permite cerrar la sesión y te redirige a la página de login.
- Muestra el nombre y el correo del usuario en la pestaña de perfil
- Corregí error donde se tenían dos instancias de material app, esto no es necesario, basta con un Scaffold como widget padre para crear un nuevo page